### PR TITLE
feat(navi-portal): smart on fhir example application

### DIFF
--- a/apps/navi-portal/src/app/demo/context/page.tsx
+++ b/apps/navi-portal/src/app/demo/context/page.tsx
@@ -1,0 +1,315 @@
+import {
+  decryptObject,
+  type SmartPreAuth,
+  type SmartSessionData,
+} from "@/lib/smart";
+import { env } from "@/env";
+import { redirect } from "next/navigation";
+import { kv } from "@vercel/kv";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function getSession(
+  ticket?: string | null
+): Promise<SmartSessionData | null> {
+  if (!ticket) return null;
+  const key = `smart:ticket:${ticket}`;
+  const data = await kv.get<SmartSessionData>(key);
+  if (!data) return null;
+  await kv.del(key);
+  return data;
+}
+
+type HumanName = {
+  text?: string;
+  given?: string[];
+  family?: string;
+};
+
+type PatientResource = {
+  id?: string;
+  name?: HumanName[];
+  gender?: string;
+  birthDate?: string;
+};
+
+type PractitionerResource = {
+  resourceType?: "Practitioner" | string;
+  id?: string;
+  name?: HumanName[];
+};
+
+type EncounterResource = {
+  resourceType?: "Encounter" | string;
+  id?: string;
+  status?: string;
+  class?: { system?: string; code?: string; display?: string };
+  period?: { start?: string; end?: string };
+};
+
+async function fetchPatient(
+  iss: string,
+  accessToken: string,
+  patientId?: string
+): Promise<PatientResource | null> {
+  if (!patientId) return null;
+  const url = `${iss.replace(/\/$/, "")}/Patient/${encodeURIComponent(
+    patientId
+  )}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      accept: "application/json",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as PatientResource;
+}
+
+function resolveRefUrl(iss: string, ref: string): string {
+  if (/^https?:\/\//i.test(ref)) return ref;
+  const base = iss.replace(/\/$/, "");
+  const path = ref.replace(/^\//, "");
+  return `${base}/${path}`;
+}
+
+async function fetchProvider(
+  iss: string,
+  accessToken: string,
+  fhirUser?: string
+): Promise<PractitionerResource | null> {
+  if (!fhirUser) return null;
+  const url = resolveRefUrl(iss, fhirUser);
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      accept: "application/json",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as PractitionerResource;
+}
+
+async function fetchEncounter(
+  iss: string,
+  accessToken: string,
+  encounter?: string
+): Promise<EncounterResource | null> {
+  if (!encounter) return null;
+  const ref = /\//.test(encounter) ? encounter : `Encounter/${encounter}`;
+  const url = resolveRefUrl(iss, ref);
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      accept: "application/json",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as EncounterResource;
+}
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ ticket?: string; code?: string; state?: string }>;
+}) {
+  const sp = await searchParams;
+  // Fallback: if redirected here directly by the OAuth server, complete the exchange inline
+  if (sp?.code && sp?.state) {
+    try {
+      const pre = await decryptObject<SmartPreAuth>(sp.state);
+      const clientId = await kv.get<string>(`smart:client-id:${pre.iss}`);
+      const body = new URLSearchParams();
+      body.set("grant_type", "authorization_code");
+      body.set("code", sp.code);
+      body.set("redirect_uri", env.SMART_REDIRECT_URI ?? "");
+      body.set("client_id", clientId ?? "");
+      body.set("code_verifier", pre.codeVerifier);
+
+      const tokenRes = await fetch(pre.tokenEndpoint, {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          accept: "application/json",
+        },
+        body,
+        cache: "no-store",
+      });
+
+      if (tokenRes.ok) {
+        const tokenJson = (await tokenRes.json()) as {
+          access_token: string;
+          token_type?: string;
+          scope?: string;
+          expires_in?: number;
+          id_token?: string;
+          patient?: string;
+          encounter?: string;
+          fhirUser?: string;
+        };
+
+        const sessionData: SmartSessionData = {
+          sid: crypto.randomUUID(),
+          iss: pre.iss,
+          tokenEndpoint: pre.tokenEndpoint,
+          accessToken: tokenJson.access_token,
+          idToken: tokenJson.id_token,
+          scope: tokenJson.scope,
+          patient: tokenJson.patient,
+          encounter: tokenJson.encounter,
+          fhirUser: tokenJson.fhirUser,
+          expiresIn: tokenJson.expires_in,
+          tokenType: tokenJson.token_type,
+        };
+
+        const ticket = crypto.randomUUID();
+        await kv.set(`smart:ticket:${ticket}`, sessionData, { ex: 120 });
+        redirect(`/demo/context?ticket=${encodeURIComponent(ticket)}`);
+        return null as never;
+      }
+    } catch {
+      // fall through to "no session" UI
+    }
+  }
+
+  const session = await getSession(sp?.ticket ?? null);
+  if (!session) {
+    return (
+      <div style={{ padding: 24 }}>
+        <h1>SMART Demo</h1>
+        <p>No session found. Start from /smart/launch</p>
+      </div>
+    );
+  }
+
+  const patient = await fetchPatient(
+    session.iss,
+    session.accessToken,
+    session.patient
+  );
+  const provider = await fetchProvider(
+    session.iss,
+    session.accessToken,
+    session.fhirUser
+  );
+  const encounter = await fetchEncounter(
+    session.iss,
+    session.accessToken,
+    session.encounter
+  );
+
+  return (
+    <div style={{ padding: 24, fontFamily: "Inter, system-ui, sans-serif" }}>
+      <h1>SMART Context</h1>
+      <pre
+        style={{
+          background: "#111",
+          color: "#eee",
+          padding: 16,
+          borderRadius: 8,
+        }}
+      >
+        {JSON.stringify(
+          {
+            iss: session.iss,
+            patient: session.patient,
+            encounter: session.encounter,
+            fhirUser: session.fhirUser,
+            scope: session.scope,
+          },
+          null,
+          2
+        )}
+      </pre>
+      <h2>Patient</h2>
+      {patient ? (
+        <pre
+          style={{
+            background: "#111",
+            color: "#eee",
+            padding: 16,
+            borderRadius: 8,
+          }}
+        >
+          {JSON.stringify(
+            {
+              id: patient.id,
+              name:
+                patient.name?.[0]?.text ??
+                ([...(patient.name?.[0]?.given ?? [])].join(" ")
+                  ? `${[...(patient.name?.[0]?.given ?? [])].join(" ")} ${
+                      patient.name?.[0]?.family ?? ""
+                    }`.trim()
+                  : undefined),
+              gender: patient.gender,
+              birthDate: patient.birthDate,
+            },
+            null,
+            2
+          )}
+        </pre>
+      ) : (
+        <p>Patient not available or fetch failed.</p>
+      )}
+
+      <h2>Provider</h2>
+      {provider ? (
+        <pre
+          style={{
+            background: "#111",
+            color: "#eee",
+            padding: 16,
+            borderRadius: 8,
+          }}
+        >
+          {JSON.stringify(
+            {
+              id: provider.id,
+              resourceType: provider.resourceType,
+              name:
+                provider.name?.[0]?.text ??
+                ([...(provider.name?.[0]?.given ?? [])].join(" ")
+                  ? `${[...(provider.name?.[0]?.given ?? [])].join(" ")} ${
+                      provider.name?.[0]?.family ?? ""
+                    }`.trim()
+                  : undefined),
+            },
+            null,
+            2
+          )}
+        </pre>
+      ) : (
+        <p>No provider info.</p>
+      )}
+
+      <h2>Encounter</h2>
+      {encounter ? (
+        <pre
+          style={{
+            background: "#111",
+            color: "#eee",
+            padding: 16,
+            borderRadius: 8,
+          }}
+        >
+          {JSON.stringify(
+            {
+              id: encounter.id,
+              status: encounter.status,
+              class: encounter.class?.display ?? encounter.class?.code,
+              period: encounter.period,
+            },
+            null,
+            2
+          )}
+        </pre>
+      ) : (
+        <p>No encounter info.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/navi-portal/src/app/smart/callback/route.ts
+++ b/apps/navi-portal/src/app/smart/callback/route.ts
@@ -1,0 +1,276 @@
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "@/env";
+import { SmartSessionData } from "@/lib/smart";
+import {
+  errorRedirect,
+  decodeState,
+  resolveClientId,
+} from "@/lib/smart/handlers";
+import { kv } from "@vercel/kv";
+
+export const runtime = "edge";
+
+type TokenResponse = {
+  access_token: string;
+  token_type?: string;
+  scope?: string;
+  expires_in?: number;
+  id_token?: string;
+  patient?: string;
+  encounter?: string;
+  fhirUser?: string;
+  sim_error?: string;
+};
+
+function normalizeErrorCode(code: string | undefined | null): string {
+  if (!code) return "simulated_error";
+  return code
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function safeDecodeJwtPayload<T>(jwt?: string): T | null {
+  if (!jwt || typeof jwt !== "string") return null;
+  try {
+    const parts = jwt.split(".");
+    if (parts.length !== 3) return null;
+    const [, payloadB64] = parts;
+    const base64 = payloadB64.replace(/-/g, "+").replace(/_/g, "/");
+    const pad = base64.length % 4 === 0 ? 0 : 4 - (base64.length % 4);
+    const decoded = atob(base64 + "=".repeat(pad));
+    return JSON.parse(decoded) as T;
+  } catch {
+    return null;
+  }
+}
+
+function detectSimulatorError(token: TokenResponse): string | null {
+  if (typeof token.sim_error === "string" && token.sim_error.length > 0) {
+    return normalizeErrorCode(token.sim_error);
+  }
+  const embedded = safeDecodeJwtPayload<{
+    auth_error?: string;
+    sim_error?: string;
+    error?: string;
+  }>(token.access_token);
+  const candidate =
+    embedded?.auth_error || embedded?.sim_error || embedded?.error;
+  return candidate ? normalizeErrorCode(candidate) : null;
+}
+
+function isExpiredToken(token: TokenResponse): boolean {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const idClaims = safeDecodeJwtPayload<{ exp?: number }>(token.id_token);
+  const idTokenExpired =
+    typeof idClaims?.exp === "number" && idClaims.exp <= nowSeconds;
+  const accessExpired =
+    typeof token.expires_in === "number" && token.expires_in <= 0;
+  return Boolean(accessExpired || idTokenExpired);
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code");
+  const state = searchParams.get("state");
+  const oauthError = searchParams.get("error");
+  const oauthErrorDescription = searchParams.get("error_description");
+
+  if (oauthError) {
+    const preTmp = await decodeState(state);
+    return errorRedirect(request, {
+      code: oauthError,
+      message: oauthErrorDescription ?? undefined,
+      iss: preTmp?.iss,
+    });
+  }
+  if (!code || !state) {
+    return NextResponse.json(
+      { error: "Missing code or state" },
+      { status: 400 }
+    );
+  }
+
+  if (!env.SMART_REDIRECT_URI) {
+    return NextResponse.json(
+      {
+        error: "SMART env not configured",
+        missing: {
+          SMART_REDIRECT_URI: !env.SMART_REDIRECT_URI,
+        },
+      },
+      { status: 500 }
+    );
+  }
+
+  // Decode pre-auth directly from encrypted state value
+  const pre = await decodeState(state);
+  if (!pre) {
+    return errorRedirect(request, {
+      code: "invalid_state",
+      message: "Invalid or missing state payload",
+    });
+  }
+
+  const body = new URLSearchParams();
+  body.set("grant_type", "authorization_code");
+  body.set("code", code);
+  body.set("redirect_uri", env.SMART_REDIRECT_URI);
+  // Resolve client_id using same KV mapping as launch
+  const clientId = await resolveClientId(pre.iss);
+  if (!clientId) {
+    return errorRedirect(request, {
+      code: "missing_client_id",
+      message: "No client_id configured for issuer",
+      iss: pre.iss,
+    });
+  }
+  body.set("client_id", clientId);
+  body.set("code_verifier", pre.codeVerifier);
+
+  let tokenRes: Response;
+  try {
+    tokenRes = await fetch(pre.tokenEndpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        accept: "application/json",
+      },
+      body,
+    });
+  } catch (err) {
+    return errorRedirect(request, {
+      code: "token_request_failed",
+      message: "Network or CORS error while contacting token endpoint",
+      iss: pre?.iss ?? "",
+    });
+  }
+
+  if (!tokenRes.ok) {
+    // Try to parse JSON error, otherwise return raw text
+    let details: unknown = null;
+    try {
+      details = await tokenRes.json();
+    } catch {
+      details = await tokenRes.text();
+    }
+    // 400 indicates invalid_client, invalid_grant, etc. Pass through status for clarity
+    return errorRedirect(request, {
+      code: "token_exchange_failed",
+      status: String(tokenRes.status),
+      message: typeof details === "string" ? details : JSON.stringify(details),
+      iss: pre?.iss ?? "",
+    });
+  }
+
+  const tokenJson = (await tokenRes.json()) as TokenResponse;
+
+  // Some simulator scenarios embed an error marker inside the JWT claims
+  // of the access_token instead of top-level fields. Detect and surface it.
+  try {
+    if (typeof tokenJson.access_token === "string") {
+      const parts = tokenJson.access_token.split(".");
+      if (parts.length === 3) {
+        const [, payloadB64] = parts;
+        const base64 = payloadB64.replace(/-/g, "+").replace(/_/g, "/");
+        const pad = base64.length % 4 === 0 ? 0 : 4 - (base64.length % 4);
+        const decoded = atob(base64 + "=".repeat(pad));
+        const claims = JSON.parse(decoded) as Partial<{
+          auth_error: string;
+          sim_error: string;
+          error: string;
+        }>;
+
+        const embedded = claims.auth_error || claims.sim_error || claims.error;
+        if (typeof embedded === "string" && embedded.length > 0) {
+          const normalized = embedded
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "_")
+            .replace(/^_+|_+$/g, "");
+          return errorRedirect(request, {
+            code: normalized || "simulated_error",
+            message: `SMART launcher embedded error in token: ${embedded}`,
+            iss: pre.iss,
+            status: 200,
+          });
+        }
+      }
+    }
+  } catch {
+    // ignore parse errors
+  }
+
+  // Use unified simulator detection (top-level sim_error or embedded claim)
+  const simCode = detectSimulatorError(tokenJson);
+  if (simCode) {
+    return errorRedirect(request, {
+      code: simCode,
+      message: `SMART launcher simulated error: ${simCode}`,
+      iss: pre.iss,
+      status: 200,
+    });
+  }
+  // Detect mocked/expired tokens from the test launcher
+  // - expires_in <= 0 indicates an already expired access token
+  // - id_token with past exp also indicates expiry
+  if (isExpiredToken(tokenJson)) {
+    return errorRedirect(request, {
+      code: "expired_token",
+      message:
+        "Authorization server returned an expired token during exchange.",
+      iss: pre.iss,
+      status: 200,
+    });
+  }
+
+  // Extract fhirUser/profile from id_token claims if present
+  let fhirUserFromIdToken: string | undefined;
+  if (tokenJson.id_token) {
+    try {
+      const [, payloadB64] = tokenJson.id_token.split(".");
+      if (payloadB64) {
+        const base64 = payloadB64.replace(/-/g, "+").replace(/_/g, "/");
+        const pad = base64.length % 4 === 0 ? 0 : 4 - (base64.length % 4);
+        const decoded = atob(base64 + "=".repeat(pad));
+        const claims = JSON.parse(decoded) as Partial<{
+          fhirUser: string;
+          profile: string;
+        }>;
+        fhirUserFromIdToken = claims.fhirUser || claims.profile;
+      }
+    } catch {
+      // ignore parse errors and continue
+    }
+  }
+
+  const sessionData: SmartSessionData = {
+    sid: crypto.randomUUID(),
+    iss: pre.iss,
+    tokenEndpoint: pre.tokenEndpoint,
+    accessToken: tokenJson.access_token,
+    idToken: tokenJson.id_token,
+    scope: tokenJson.scope,
+    patient: tokenJson.patient,
+    encounter: tokenJson.encounter,
+    fhirUser: tokenJson.fhirUser ?? fhirUserFromIdToken,
+    expiresIn: tokenJson.expires_in,
+    tokenType: tokenJson.token_type,
+  };
+
+  // Store one-time ticket in KV (short TTL)
+  const ticket = crypto.randomUUID();
+  // 120s TTL for demo; adjust as needed
+  await kv.set(`smart:ticket:${ticket}`, sessionData, { ex: 120 });
+  // Build absolute redirect URL that respects reverse proxy / ngrok headers
+  const forwardedProto = request.headers.get("x-forwarded-proto") ?? "https";
+  const forwardedHost =
+    request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  const origin = forwardedHost
+    ? `${forwardedProto}://${forwardedHost}`
+    : new URL(request.url).origin;
+  const demoUrl = new URL("/demo/context", origin);
+  demoUrl.searchParams.set("ticket", ticket);
+  return NextResponse.redirect(demoUrl.toString(), 302);
+}

--- a/apps/navi-portal/src/app/smart/error/page.tsx
+++ b/apps/navi-portal/src/app/smart/error/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { Typography } from "@/components/ui";
+import { useSearchParams } from "next/navigation";
+
+export default function Page() {
+  const sp = useSearchParams();
+  const code = sp.get("code") ?? "unknown_error";
+  const message =
+    sp.get("message") ?? "An unexpected error occurred during SMART launch.";
+  const status = sp.get("status");
+  const iss = sp.get("iss");
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <Typography.H1>SMART Launch Error</Typography.H1>
+      <Typography.P>
+        Something went wrong while connecting to the EHR. Please try again.
+      </Typography.P>
+      <pre className="bg-primary/10 px-2 py-1 rounded font-mono">
+        {JSON.stringify(
+          {
+            code,
+            status,
+            message,
+            iss,
+          },
+          null,
+          2
+        )}
+      </pre>
+      <Typography.P>
+        If this persists, contact support with the error details above.
+      </Typography.P>
+    </div>
+  );
+}

--- a/apps/navi-portal/src/app/smart/launch/route.ts
+++ b/apps/navi-portal/src/app/smart/launch/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "@/env";
+import {
+  discoverSmartConfiguration,
+  encryptObject,
+  generatePKCE,
+  SmartPreAuth,
+} from "@/lib/smart";
+import {
+  resolveClientId,
+  errorRedirect,
+  getIssuerHost,
+} from "@/lib/smart/handlers";
+
+export const runtime = "edge";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const iss = searchParams.get("iss");
+  const launch = searchParams.get("launch") ?? undefined;
+
+  if (!iss) {
+    return NextResponse.json(
+      { error: "Missing iss parameter" },
+      { status: 400 }
+    );
+  }
+
+  if (!env.SMART_REDIRECT_URI) {
+    return NextResponse.json(
+      {
+        error: "SMART env not configured",
+        missing: {
+          SMART_REDIRECT_URI: !env.SMART_REDIRECT_URI,
+        },
+      },
+      { status: 500 }
+    );
+  }
+
+  let authorization_endpoint: string;
+  let token_endpoint: string;
+  try {
+    const discovered = await discoverSmartConfiguration(iss);
+    authorization_endpoint = discovered.authorization_endpoint;
+    token_endpoint = discovered.token_endpoint;
+  } catch (err) {
+    const forwardedProto = request.headers.get("x-forwarded-proto") ?? "https";
+    const forwardedHost =
+      request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+    const origin = forwardedHost
+      ? `${forwardedProto}://${forwardedHost}`
+      : new URL(request.url).origin;
+    const errorUrl = new URL("/smart/error", origin);
+    errorUrl.searchParams.set("code", "discovery_failed");
+    errorUrl.searchParams.set("message", "Failed to load SMART configuration");
+    errorUrl.searchParams.set("iss", iss);
+    return NextResponse.redirect(errorUrl.toString(), 302);
+  }
+
+  const scopes = [
+    "launch",
+    "openid",
+    "fhirUser",
+    "launch/patient",
+    "launch/encounter",
+    "patient/*.read",
+  ].join(" ");
+
+  const { codeVerifier, codeChallenge } = await generatePKCE();
+  const state = crypto.randomUUID();
+
+  const preAuth: SmartPreAuth = {
+    iss,
+    authorizationEndpoint: authorization_endpoint,
+    tokenEndpoint: token_endpoint,
+    codeVerifier,
+    state,
+    scopes,
+    launch,
+  };
+
+  // Encode pre-auth into state to avoid third-party cookies
+  const encryptedState = await encryptObject(preAuth);
+
+  // Resolve client_id from KV mapping (fallback to env)
+  const issuerKey = getIssuerHost(iss);
+  const clientId = await resolveClientId(iss);
+  if (!clientId) {
+    return errorRedirect(request, {
+      code: "missing_client_id",
+      message: `No client_id configured for issuer host: ${issuerKey}`,
+      iss,
+    });
+  }
+
+  const redirectUrl = new URL(authorization_endpoint);
+  redirectUrl.searchParams.set("response_type", "code");
+  redirectUrl.searchParams.set("client_id", clientId);
+  redirectUrl.searchParams.set("redirect_uri", env.SMART_REDIRECT_URI);
+  redirectUrl.searchParams.set("scope", scopes);
+  redirectUrl.searchParams.set("state", encryptedState);
+  redirectUrl.searchParams.set("aud", iss);
+  redirectUrl.searchParams.set("code_challenge", codeChallenge);
+  redirectUrl.searchParams.set("code_challenge_method", "S256");
+  if (launch) redirectUrl.searchParams.set("launch", launch);
+
+  return NextResponse.redirect(redirectUrl.toString(), 302);
+}

--- a/apps/navi-portal/src/app/smart/layout.tsx
+++ b/apps/navi-portal/src/app/smart/layout.tsx
@@ -1,0 +1,32 @@
+import { generateThemeCSS } from "@/lib/branding";
+import { getBrandingByOrgId } from "@/lib/branding/branding-service";
+import "../globals.css";
+import { Suspense } from "react";
+import { LoaderCircle } from "lucide-react";
+
+export const runtime = "nodejs";
+
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const orgBranding = await getBrandingByOrgId("default");
+  const css = generateThemeCSS(orgBranding);
+  return (
+    <html>
+      <head>
+        {css ? <style dangerouslySetInnerHTML={{ __html: css }} /> : null}
+      </head>
+      <Suspense
+        fallback={
+          <div className="flex justify-center items-center h-screen">
+            <LoaderCircle className="animate-spin" />
+          </div>
+        }
+      >
+        <body>{children}</body>
+      </Suspense>
+    </html>
+  );
+}

--- a/apps/navi-portal/src/env.ts
+++ b/apps/navi-portal/src/env.ts
@@ -46,6 +46,12 @@ export const env = createEnv({
       .describe(
         "Stytch environment: test or live (optional, defaults to test)"
       ),
+    SMART_REDIRECT_URI: z
+      .url()
+      .optional()
+      .describe(
+        "Redirect URI for SMART callback (e.g. https://app.example.com/smart/callback)"
+      ),
   },
   client: {
     NEXT_PUBLIC_GRAPHQL_ENDPOINT: z

--- a/apps/navi-portal/src/lib/smart/handlers.ts
+++ b/apps/navi-portal/src/lib/smart/handlers.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { kv } from "@vercel/kv";
+import { decryptObject, SmartPreAuth } from "@/lib/smart";
+
+export function getIssuerHost(iss: string): string {
+  try {
+    return new URL(iss).host;
+  } catch {
+    return iss.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+  }
+}
+
+export function buildOrigin(request: NextRequest): string {
+  const proto = request.headers.get("x-forwarded-proto") ?? "https";
+  const host =
+    request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  return host ? `${proto}://${host}` : new URL(request.url).origin;
+}
+
+export function errorRedirect(
+  request: NextRequest,
+  params: {
+    code: string;
+    message?: string;
+    status?: number | string;
+    iss?: string;
+  }
+): NextResponse {
+  const origin = buildOrigin(request);
+  const url = new URL("/smart/error", origin);
+  url.searchParams.set("code", params.code);
+  if (params.message) url.searchParams.set("message", params.message);
+  if (params.status !== undefined)
+    url.searchParams.set("status", String(params.status));
+  if (params.iss) url.searchParams.set("iss", params.iss);
+  return NextResponse.redirect(url.toString(), 302);
+}
+
+export async function resolveClientId(iss: string): Promise<string | null> {
+  const host = getIssuerHost(iss);
+  const fromKv = await kv.get<string>(`smart:client-id:${host}`);
+  return fromKv ?? null;
+}
+
+export async function decodeState(
+  state?: string | null
+): Promise<SmartPreAuth | null> {
+  if (!state) return null;
+  try {
+    return await decryptObject<SmartPreAuth>(state);
+  } catch {
+    return null;
+  }
+}

--- a/apps/navi-portal/src/lib/smart/index.ts
+++ b/apps/navi-portal/src/lib/smart/index.ts
@@ -1,0 +1,180 @@
+import { env } from "@/env";
+
+function toBase64Url(input: ArrayBuffer | Uint8Array): string {
+  const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i] as number);
+  }
+  const base64 = btoa(binary);
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function fromBase64Url(input: string): Uint8Array {
+  const base64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = base64.length % 4 === 0 ? 0 : 4 - (base64.length % 4);
+  const base64Padded = base64 + "=".repeat(pad);
+  const binary = atob(base64Padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export async function sha256(value: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return toBase64Url(digest);
+}
+
+export function randomString(bytes: number = 32): string {
+  const random = crypto.getRandomValues(new Uint8Array(bytes));
+  return toBase64Url(random);
+}
+
+export async function generatePKCE(): Promise<{
+  codeVerifier: string;
+  codeChallenge: string;
+}> {
+  const codeVerifier = randomString(32);
+  const codeChallenge = await sha256(codeVerifier);
+  return { codeVerifier, codeChallenge };
+}
+
+async function getAesGcmKey(): Promise<CryptoKey> {
+  const keyBytes = normalizeKeyToBytes(env.TOKEN_ENCRYPTION_KEY);
+  return crypto.subtle.importKey(
+    "raw",
+    keyBytes,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"]
+  );
+}
+
+function normalizeKeyToBytes(key: string): Uint8Array {
+  const trimmed = key.trim();
+
+  // Try base64/base64url first (44 chars typical for 32 bytes)
+  try {
+    const bytes = fromBase64Url(trimmed);
+    if (bytes.length === 32) return bytes;
+  } catch {
+    // ignore
+  }
+
+  // Try hex (64 hex chars → 32 bytes)
+  if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+    const out = new Uint8Array(32);
+    for (let i = 0; i < 64; i += 2) {
+      out[i / 2] = parseInt(trimmed.slice(i, i + 2), 16);
+    }
+    return out;
+  }
+
+  // Fallback: interpret as 32 ASCII/UTF-8 bytes
+  if (trimmed.length === 32) {
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(trimmed);
+    if (bytes.length === 32) return bytes;
+  }
+
+  throw new Error(
+    "TOKEN_ENCRYPTION_KEY must be 32 bytes (provide as base64/base64url, 64-char hex, or 32-char raw)."
+  );
+}
+
+export async function encryptObject(obj: unknown): Promise<string> {
+  const json = JSON.stringify(obj);
+  const encoder = new TextEncoder();
+  const data = encoder.encode(json);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await getAesGcmKey();
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    data
+  );
+  const combined = new Uint8Array(
+    iv.length + (ciphertext as ArrayBuffer).byteLength
+  );
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(ciphertext as ArrayBuffer), iv.length);
+  return toBase64Url(combined);
+}
+
+export async function decryptObject<T>(token: string): Promise<T> {
+  const raw = fromBase64Url(token);
+  const iv = raw.slice(0, 12);
+  const data = raw.slice(12);
+  const key = await getAesGcmKey();
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    data
+  );
+  const decoder = new TextDecoder();
+  const json = decoder.decode(plaintext);
+  return JSON.parse(json) as T;
+}
+
+export interface SmartPreAuth {
+  iss: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  codeVerifier: string;
+  state: string;
+  scopes: string;
+  launch?: string;
+}
+
+export interface SmartSessionData {
+  sid: string;
+  iss: string;
+  tokenEndpoint: string;
+  accessToken: string;
+  idToken?: string;
+  scope?: string;
+  patient?: string;
+  encounter?: string;
+  fhirUser?: string;
+  expiresIn?: number;
+  tokenType?: string;
+}
+
+export async function discoverSmartConfiguration(iss: string): Promise<{
+  authorization_endpoint: string;
+  token_endpoint: string;
+}> {
+  const wellKnownUrls = [
+    `${iss.replace(/\/$/, "")}/.well-known/smart-configuration`,
+    `${iss.replace(/\/$/, "")}/.well-known/oauth-authorization-server`,
+  ];
+  let lastError: unknown;
+  for (const url of wellKnownUrls) {
+    try {
+      const res = await fetch(url, { headers: { accept: "application/json" } });
+      if (res.ok) {
+        const json = (await res.json()) as {
+          authorization_endpoint?: string;
+          token_endpoint?: string;
+        };
+        if (json.authorization_endpoint && json.token_endpoint) {
+          return {
+            authorization_endpoint: json.authorization_endpoint,
+            token_endpoint: json.token_endpoint,
+          };
+        }
+      }
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw new Error(
+    `Unable to discover SMART configuration for issuer: ${iss}${
+      lastError ? " (" + String(lastError) + ")" : ""
+    }`
+  );
+}


### PR DESCRIPTION
### SMART auth: robust token error handling + lib consolidation

- Consolidated SMART helpers into `apps/navi-portal/src/lib/smart/index.ts` and removed the old flat `lib/smart.ts`.
- Kept `apps/navi-portal/src/lib/smart/handlers.ts` as the place for request/response utilities (`errorRedirect`, `resolveClientId`, `decodeState`, `getIssuerHost`, `buildOrigin`).

### Launch flow
- `src/app/smart/launch/route.ts`
  - Discovers SMART endpoints.
  - Builds PKCE + encrypted state via `encryptObject(preAuth)` to avoid 3rd‑party cookies.
  - Resolves `client_id` via KV or env; redirects with clear error if missing.

### Callback flow
- `src/app/smart/callback/route.ts`
  - Refactor for clarity with small helpers:
    - `normalizeErrorCode`, `safeDecodeJwtPayload`
    - `detectSimulatorError` to handle both top‑level `sim_error` and errors embedded in the access_token’s JWT claims (e.g., `auth_error`, `sim_error`, `error`).
    - `isExpiredToken` to detect `expires_in <= 0` or `id_token.exp` in the past.
  - Unified error redirects using `errorRedirect` for:
    - OAuth errors returned on the callback URL.
    - Network/CORS failures contacting the token endpoint.
    - Non‑2xx token responses (propagates HTTP status and details).
    - Simulator scenarios and expired tokens.
  - Stores a short‑lived KV ticket for the demo context handoff.

### Error UI
- `src/app/smart/error/page.tsx`
  - Client component rendering a simple, consistent error summary via `Typography` with code/status/message/iss.

### Why
- SMART Health IT launcher sometimes returns 200 with simulated errors either in `sim_error` or embedded JWT claims. These cases now route reliably to `/smart/error` with normalized codes (`expired_token`, `invalid_token`, etc.).
- Code is easier to read/maintain with helpers and centralized redirects.
- Imports now consistently use `@/lib/smart` (folder index) instead of a mix of file and folder paths.

No breaking API changes for consumers using `@/lib/smart` or `@/lib/smart/handlers`.